### PR TITLE
Deploys to docs to gh-pages

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,4 @@
-using Documenter
-using DoseCalculations
+using Documenter, DoseCalculations
 
 makedocs(
     modules = [DoseCalculations],
@@ -8,4 +7,8 @@ makedocs(
         "Dose Calculation Algorithms"=>["ScaledIsoplaneKernel.md",
         ]
     ]
+    )
+
+deploydocs(
+    repo = "github.com/ACRF-Image-X-Institute/DoseCalculations.jl.git",
     )


### PR DESCRIPTION
This adds adds a call to [`Documenter.deploydocs`](https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#The-deploydocs-Function), which is required to deploy the docs to the `gh-pages` branch.