### PR TITLE
Updated DosePositions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DoseCalculations"
 uuid = "b0d14063-c48a-4081-83d5-5a5ab48cb495"
 authors = ["lmejn <33491793+lmejn@users.noreply.github.com>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+DoseCalculations = "b0d14063-c48a-4081-83d5-5a5ab48cb495"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/examples/dose-reconstruction.jl
+++ b/examples/dose-reconstruction.jl
@@ -14,12 +14,13 @@ calc = ScaledIsoplaneKernel("examples/sample-data/dose-kernel/scaled-isoplane-ke
 calibrate!(calc, 100., 100., 1000.)
 
 # Create dose points
-pos = DoseGrid(5., CylinderBounds(200., 200., SVector(0., 0., 0.)))
+pos = DoseGridMasked(5., CylinderBounds(200., 200., getisocenter(plan[1])))
 
 # Load external surface
 surf = PlaneSurface(800.)
 
 # Reconstruct Dose
 dose = reconstruct_dose(pos, surf, plan, calc)
-save("dose", pos, Dict("dose"=>dose))
+
+save("dose", pos, "dose"=>dose)
 

--- a/examples/water-phantom.jl
+++ b/examples/water-phantom.jl
@@ -1,17 +1,22 @@
 #=
-    Compute the dose on a water phantom for a square field
+    Compute the dose in a water phantom for a square field
 
-Compute the dose at various depths in a water phantom, with a 10x10cm² square
-field. Uses a plane surface, located at SAD.
+Compute the dose at various depths and off-axis positions in a water phantom
+with a 10x10cm² square field. Uses a plane surface, located at SAD.
+
+Computes the dose for three dose profiles:
+- The depth-dose curve along the central axis
+- The off-axis profile at a depth of 100 mm
+- A 2D dose distribution.
 =#
 
 using DoseCalculations
-using Plots, Meshes, LsqFit
+using Plots, StaticArrays
+
+#--- Setup Dose Calculation --------------------------------------------------------------------------------------------
 
 # Set Fieldsize
 fieldsize = 100.
-ϕg = 0.
-θb = 0.
 SAD = 1000.
 
 SSD = SAD
@@ -26,22 +31,57 @@ calc = ScaledIsoplaneKernel("examples/sample-data/dose-kernel/scaled-isoplane-ke
 MU = 100.
 calibrate!(calc, MU, fieldsize, SSD)
 
-# Create dose points in IEC BLD coordinates
-zp = -SAD-400:1.:-SAD
-pos = Vec.(0., 0., zp)
-
 # Create External Surface
 surf = PlaneSurface(SAD)
 
-depth = getdepth.(Ref(surf), pos)
+gantry = GantryPosition(0., 0., SAD)
 
-# Create dose-fluence matrix
-@time dose = dose_fluence_matrix(pos, vec(bixels), surf, calc)
+#--- Depth Dose --------------------------------------------------------------------------------------------------------
 
-depth = getdepth.(Ref(surf), pos)
+# Create dose points
+zp = -400:1.:0
+pos = SVector.(0., 0., zp)
+
+# Calculate dose
+@time depth_dose = dose_fluence_matrix(pos, vec(bixels), gantry, surf, calc)[1, :]
+
 begin
+    depth = getdepth.(Ref(surf), fixed_to_bld(gantry).(pos))
     p = plot(xlabel="Depth (mm)", ylabel="Dose (Gy)", ylim=[0, Inf])
-    plot!(depth, MU*vec(dose), label="Calculated")
-    plot!(depth, MU*norm_depth_dose.(Ref(calc), depth), label="Measured")
+    plot!(depth, MU*vec(depth_dose), label="Calculated")
+    plot!(depth, MU*DoseCalculations.norm_depth_dose.(Ref(calc), depth))
     hline!([1.], color=:black, label="")
+end
+
+#--- Off-Axis Profile --------------------------------------------------------------------------------------------------
+
+# Create dose points
+depth = 100.
+xp = -200.:1.:200.
+pos = SVector.(xp, 0., -depth)
+
+# Calculate dose
+@time offaxis_dose = dose_fluence_matrix(pos, vec(bixels), gantry, surf, calc)[1, :]
+
+# Plot
+begin
+    p = plot(xlabel="Off-Axis Position (mm)", ylabel="Dose (Gy)", ylim=[0, Inf])
+    plot!(xp, MU*offaxis_dose, label="Depth=$depth mm")
+end
+
+#--- 2D Dose -----------------------------------------------------------------------------------------------------------
+
+# Create dose points
+depth = 0:5.:400
+offaxis_pos = -200.:5.:200.
+pos = DoseGrid(offaxis_pos, [0.], -depth)
+
+# Calculate dose
+@time dose = MU*dose_fluence_matrix(pos, vec(bixels), gantry, surf, calc)
+dose = reshape(Array(dose), size(pos));
+
+# Plot
+begin
+    p = plot(xlabel="Off-Axis Position (mm)", ylabel="Depth (mm)")
+    heatmap!(p, offaxis_pos, depth, dose[:, 1, :]', colorbar_title="Dose (Gy)")
 end

--- a/src/DoseCalculationAlgorithms/ScaledIsoplaneKernel.jl
+++ b/src/DoseCalculationAlgorithms/ScaledIsoplaneKernel.jl
@@ -17,9 +17,8 @@ end
 
 function ScaledIsoplaneKernel(filename::String, max_kernel_radius; δsub=SVector(1., 1.))
 
-    data = Dict()
-    open(filename, "r") do f
-        data = JSON.parse(read(f, String))
+    data = open(filename, "r") do f
+        JSON.parse(read(f, String))
     end
 
     ref_depth = data["Ref. Depth"]

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -105,7 +105,7 @@ function vtk_generate_file(filename, pos::DoseGrid)
     vtk_grid(filename, points, cells)
 end
 
-function save(filename::String, pos::DoseGrid, data)
+function save(filename::String, pos::DoseGrid, data::Vararg) #
     vtkfile = vtk_generate_file(filename, pos)
     for (key, value) in data
         vtkfile[key, VTKPointData()] = value

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -4,18 +4,122 @@ using SparseArrays, StaticArrays
 
 export save, DoseGrid, CylinderBounds, gridsize, MeshBounds
 
+#--- Dose Positions ----------------------------------------------------------------------------------------------------
 
-# Dose Positions
 abstract type DosePositions end
 
 Base.iterate(pos::DosePositions) = iterate(pos, 1)
 function Base.iterate(pos::DosePositions, i)
-    if(i>length(pos)) return nothing end
+    i>length(pos) && return nothing
     pos[i], i+1
 end
 
-function Base.:+(pos::T, x) where T<:DosePositions
-    T(pos.x .+ x[1], pos.y .+ x[2], pos.z .+ x[3])
+#--- DoseGrid ----------------------------------------------------------------------------------------------------------
+
+struct DoseGrid{Tx<:AbstractVector, Ty<:AbstractVector, Tz<:AbstractVector} <: DosePositions
+    x::Tx
+    y::Ty
+    z::Tz
+    indices::Vector{CartesianIndex{3}}
+    cells::Vector{Vector{Int}}
+end
+
+function DoseGrid(Δ, bounds::AbstractBounds)
+    xmin, xmax, ymin, ymax, zmin, zmax = boundsextent(bounds)
+
+    x = xmin:Δ:xmax
+    y = ymin:Δ:ymax
+    z = zmin:Δ:zmax
+
+    grid_index = CartesianIndices( (length(x), length(y), length(z)) )
+    indices = CartesianIndex{3}[]
+    linear_index = zeros(Int, length(x), length(y), length(z))
+
+    # Points
+    for i in grid_index
+        p = SVector(x[i[1]], y[i[2]], z[i[3]])
+        if(within(bounds, p))
+            push!(indices, grid_index[i])
+            linear_index[i] = length(indices)
+        end
+    end
+
+    # Cells
+
+    neighbours = vec([CartesianIndex(i,j,k) for i=0:1, j=0:1, k=0:1])[2:end]
+
+    cells = Vector{Int}[]
+    for i in eachindex(indices)
+        cell = [i]
+        for n in neighbours
+            index = indices[i] + n
+
+            if(checkbounds(Bool, linear_index, index) && linear_index[index] != 0)
+                push!(cell, linear_index[index])
+            end
+        end
+        if(length(cell)==8)
+            push!(cells, cell)
+        end
+    end
+
+    DoseGrid(x, y, z, indices, cells)
+end
+
+Base.:+(pos::DoseGrid, x) = DoseGrid(pos.x .+ x[1], pos.y .+ x[2], pos.z .+ x[3], pos.indices)
+
+Base.length(pos::DoseGrid) = length(pos.indices)
+Base.size(pos::DoseGrid) = (length(pos),)
+
+gridsize(pos::DoseGrid) = (length(pos.x), length(pos.y), length(pos.z))
+
+Base.getindex(pos::DoseGrid, i::Int, j::Int, k::Int) = SVector(pos.x[i], pos.y[j], pos.z[k])
+Base.getindex(pos::DoseGrid, i::CartesianIndex{3}) = pos[i[1], i[2], i[3]]
+Base.getindex(pos::DoseGrid, i::Int) = pos[pos.indices[i]]
+
+Base.eachindex(pos::DoseGrid) = eachindex(pos.indices)
+Base.CartesianIndices(pos::DoseGrid) = pos.indices
+
+#--- IO
+
+function Base.show(io::IO, pos::DoseGrid)
+    print(io, "x=")
+    Base.show(io, pos.x)
+    print(io, " y=")
+    Base.show(io, pos.y)
+    print(io, " z=")
+    Base.show(io, pos.z)
+    println(io, " npts=", length(pos.indices))
+end
+
+function vtk_create_cell(cell)
+    n = length(cell)
+    n==5 && return MeshCell(VTKCellTypes.VTK_PYRAMID, cell)
+    n==6 && return MeshCell(VTKCellTypes.VTK_WEDGE, cell)
+    n==8 && return MeshCell(VTKCellTypes.VTK_VOXEL, cell)
+    
+end
+
+function vtk_generate_file(filename, pos::DoseGrid)
+    points = [pos[i] for i in eachindex(pos)]
+    cells = [vtk_create_cell(cell) for cell in pos.cells]
+    vtk_grid(filename, points, cells)
+end
+
+function vtk_grid_data(pos::DoseGrid, arr)  
+    grid_arr = zeros(size(pos))
+    for i in eachindex(arr)
+        grid_arr[pos.indices[i]] = arr[i]
+    end
+    grid_arr
+end
+
+function save(filename::String, pos::DoseGrid, data)
+    vtkfile = vtk_generate_file(filename, pos)
+    for (key, value) in data
+        vtkfile[key, VTKPointData()] = value
+    end
+    vtk_save(vtkfile)
 end
 
 #--- Bounds ------------------------------------------------------------------------------------------------------------
@@ -132,115 +236,3 @@ function within(bounds::MeshBounds, p)
     length(pI) % 2 != 0
 end
 
-# DoseGrid
-
-struct DoseGrid{Tx<:AbstractVector, Ty<:AbstractVector, Tz<:AbstractVector}
-    x::Tx
-    y::Ty
-    z::Tz
-    indices::Vector{CartesianIndex{3}}
-    cells::Vector{Vector{Int}}
-end
-
-
-function Base.show(io::IO, pos::DoseGrid)
-    print(io, "x=")
-    Base.show(io, pos.x)
-    print(io, " y=")
-    Base.show(io, pos.y)
-    print(io, " z=")
-    Base.show(io, pos.z)
-    println(io, " npts=", length(pos.indices))
-end
-Base.:+(pos::DoseGrid, x) = DoseGrid(pos.x .+ x[1], pos.y .+ x[2], pos.z .+ x[3], pos.indices)
-
-Base.length(pos::DoseGrid) = length(pos.indices)
-Base.size(pos::DoseGrid) = (length(pos),)
-
-gridsize(pos::DoseGrid) = (length(pos.x), length(pos.y), length(pos.z))
-
-Base.getindex(pos::DoseGrid, i::Int, j::Int, k::Int) = SVector(pos.x[i], pos.y[j], pos.z[k])
-Base.getindex(pos::DoseGrid, i::CartesianIndex{3}) = pos[i[1], i[2], i[3]]
-Base.getindex(pos::DoseGrid, i::Int) = pos[pos.indices[i]]
-
-Base.eachindex(pos::DoseGrid) = eachindex(pos.indices)
-Base.CartesianIndices(pos::DoseGrid) = pos.indices
-
-Base.iterate(pos::DoseGrid) = iterate(pos, 1)
-function Base.iterate(pos::DoseGrid, i)
-    if(i>length(pos)) return nothing end
-    pos[i], i+1
-end
-
-function DoseGrid(Δ::T, bounds) where T<:Number
-    xmin, xmax, ymin, ymax, zmin, zmax = boundsextent(bounds)
-
-    x = xmin:Δ:xmax
-    y = ymin:Δ:ymax
-    z = zmin:Δ:zmax
-
-    grid_index = CartesianIndices( (length(x), length(y), length(z)) )
-    indices = CartesianIndex{3}[]
-    linear_index = zeros(Int, length(x), length(y), length(z))
-
-    # Points
-    for i in grid_index
-        p = SVector(x[i[1]], y[i[2]], z[i[3]])
-        if(within(bounds, p))
-            push!(indices, grid_index[i])
-            linear_index[i] = length(indices)
-        end
-    end
-
-    # Cells
-
-    neighbours = vec([CartesianIndex(i,j,k) for i=0:1, j=0:1, k=0:1])[2:end]
-
-    cells = Vector{Int}[]
-    for i in eachindex(indices)
-        cell = [i]
-        for n in neighbours
-            index = indices[i] + n
-
-            if(checkbounds(Bool, linear_index, index) && linear_index[index] != 0)
-                push!(cell, linear_index[index])
-            end
-        end
-        if(length(cell)==8)
-            push!(cells, cell)
-        end
-    end
-
-    DoseGrid(x, y, z, indices, cells)
-end
-
-
-function vtk_create_cell(cell)
-    n = length(cell)
-    n==5 && return MeshCell(VTKCellTypes.VTK_PYRAMID, cell)
-    n==6 && return MeshCell(VTKCellTypes.VTK_WEDGE, cell)
-    n==8 && return MeshCell(VTKCellTypes.VTK_VOXEL, cell)
-    
-end
-
-function vtk_generate_file(filename, pos::DoseGrid)
-    points = [pos[i] for i in eachindex(pos)]
-    cells = [vtk_create_cell(cell) for cell in pos.cells]
-    vtk_grid(filename, points, cells)
-end
-
-function vtk_grid_data(pos::DoseGrid, arr)  
-    grid_arr = zeros(size(pos))
-    for i in eachindex(arr)
-        grid_arr[pos.indices[i]] = arr[i]
-    end
-    grid_arr
-end
-
-function save(filename::String, pos::DoseGrid, data)
-    vtkfile = vtk_generate_file(filename, pos)
-    for (key, value) in data
-        vtkfile[key, VTKPointData()] = value
-    end
-    vtk_save(vtkfile)
-end

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -188,6 +188,7 @@ function save(filename::String, pos::DoseGrid, data::Vararg)
         end
     end
 end
+save(filename::String, pos::DoseGrid, data::Dict) =  save(filename, pos, data...)
 
 #--- DoseGridMasked ----------------------------------------------------------------------------------------------------
 

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -97,21 +97,12 @@ function vtk_create_cell(cell)
     n==5 && return MeshCell(VTKCellTypes.VTK_PYRAMID, cell)
     n==6 && return MeshCell(VTKCellTypes.VTK_WEDGE, cell)
     n==8 && return MeshCell(VTKCellTypes.VTK_VOXEL, cell)
-    
 end
 
 function vtk_generate_file(filename, pos::DoseGrid)
     points = [pos[i] for i in eachindex(pos)]
-    cells = [vtk_create_cell(cell) for cell in pos.cells]
+    cells = vtk_create_cell.(pos.cells)
     vtk_grid(filename, points, cells)
-end
-
-function vtk_grid_data(pos::DoseGrid, arr)  
-    grid_arr = zeros(size(pos))
-    for i in eachindex(arr)
-        grid_arr[pos.indices[i]] = arr[i]
-    end
-    grid_arr
 end
 
 function save(filename::String, pos::DoseGrid, data)

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -4,6 +4,8 @@ using SparseArrays, StaticArrays
 
 export save, DoseGrid, DoseGridMasked, CylinderBounds, gridsize, MeshBounds
 
+export getx, gety, getz
+
 #--- Bounds ------------------------------------------------------------------------------------------------------------
 
 abstract type AbstractBounds end
@@ -142,11 +144,21 @@ abstract type AbstractDoseGrid <: DosePositions end
 Base.getindex(pos::AbstractDoseGrid, i::Vararg{Int, 3}) = SVector(getindex.(pos.axes, i)...)
 Base.getindex(pos::AbstractDoseGrid, i::CartesianIndex{3}) = pos[i[1], i[2], i[3]]
 
+getx(pos::AbstractDoseGrid) = pos.axes[1]
+gety(pos::AbstractDoseGrid) = pos.axes[2]
+getz(pos::AbstractDoseGrid) = pos.axes[3]
+
 #--- DoseGrid ----------------------------------------------------------------------------------------------------------
 
 struct DoseGrid{TVec<:AbstractVector} <: AbstractDoseGrid
     axes::SVector{3, TVec}
-    DoseGrid(x, y, z) = new{typeof(x)}(SVector(x, y, z))
+    function DoseGrid(x, y, z)
+        ax = x, y, z
+        if(!all(@. typeof(ax) <: StepRangeLen))
+            ax = collect.(ax)
+        end
+        new{typeof(ax[1])}(SVector(ax...))
+    end
 end
 
 function DoseGrid(Δ, bounds::AbstractBounds)

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -4,115 +4,6 @@ using SparseArrays, StaticArrays
 
 export save, DoseGrid, CylinderBounds, gridsize, MeshBounds
 
-#--- Dose Positions ----------------------------------------------------------------------------------------------------
-
-abstract type DosePositions end
-
-Base.iterate(pos::DosePositions) = iterate(pos, 1)
-function Base.iterate(pos::DosePositions, i)
-    i>length(pos) && return nothing
-    pos[i], i+1
-end
-
-#--- DoseGrid ----------------------------------------------------------------------------------------------------------
-
-struct DoseGrid{Tx<:AbstractVector, Ty<:AbstractVector, Tz<:AbstractVector} <: DosePositions
-    x::Tx
-    y::Ty
-    z::Tz
-    indices::Vector{CartesianIndex{3}}
-    cells::Vector{Vector{Int}}
-end
-
-function DoseGrid(Δ, bounds::AbstractBounds)
-    xmin, xmax, ymin, ymax, zmin, zmax = boundsextent(bounds)
-
-    x = xmin:Δ:xmax
-    y = ymin:Δ:ymax
-    z = zmin:Δ:zmax
-
-    grid_index = CartesianIndices( (length(x), length(y), length(z)) )
-    indices = CartesianIndex{3}[]
-    linear_index = zeros(Int, length(x), length(y), length(z))
-
-    # Points
-    for i in grid_index
-        p = SVector(x[i[1]], y[i[2]], z[i[3]])
-        if(within(bounds, p))
-            push!(indices, grid_index[i])
-            linear_index[i] = length(indices)
-        end
-    end
-
-    # Cells
-
-    neighbours = vec([CartesianIndex(i,j,k) for i=0:1, j=0:1, k=0:1])[2:end]
-
-    cells = Vector{Int}[]
-    for i in eachindex(indices)
-        cell = [i]
-        for n in neighbours
-            index = indices[i] + n
-
-            if(checkbounds(Bool, linear_index, index) && linear_index[index] != 0)
-                push!(cell, linear_index[index])
-            end
-        end
-        if(length(cell)==8)
-            push!(cells, cell)
-        end
-    end
-
-    DoseGrid(x, y, z, indices, cells)
-end
-
-Base.:+(pos::DoseGrid, x) = DoseGrid(pos.x .+ x[1], pos.y .+ x[2], pos.z .+ x[3], pos.indices)
-
-Base.length(pos::DoseGrid) = length(pos.indices)
-Base.size(pos::DoseGrid) = (length(pos),)
-
-gridsize(pos::DoseGrid) = (length(pos.x), length(pos.y), length(pos.z))
-
-Base.getindex(pos::DoseGrid, i::Int, j::Int, k::Int) = SVector(pos.x[i], pos.y[j], pos.z[k])
-Base.getindex(pos::DoseGrid, i::CartesianIndex{3}) = pos[i[1], i[2], i[3]]
-Base.getindex(pos::DoseGrid, i::Int) = pos[pos.indices[i]]
-
-Base.eachindex(pos::DoseGrid) = eachindex(pos.indices)
-Base.CartesianIndices(pos::DoseGrid) = pos.indices
-
-#--- IO
-
-function Base.show(io::IO, pos::DoseGrid)
-    print(io, "x=")
-    Base.show(io, pos.x)
-    print(io, " y=")
-    Base.show(io, pos.y)
-    print(io, " z=")
-    Base.show(io, pos.z)
-    println(io, " npts=", length(pos.indices))
-end
-
-function vtk_create_cell(cell)
-    n = length(cell)
-    n==5 && return MeshCell(VTKCellTypes.VTK_PYRAMID, cell)
-    n==6 && return MeshCell(VTKCellTypes.VTK_WEDGE, cell)
-    n==8 && return MeshCell(VTKCellTypes.VTK_VOXEL, cell)
-end
-
-function vtk_generate_file(filename, pos::DoseGrid)
-    points = [pos[i] for i in eachindex(pos)]
-    cells = vtk_create_cell.(pos.cells)
-    vtk_grid(filename, points, cells)
-end
-
-function save(filename::String, pos::DoseGrid, data::Vararg) #
-    vtkfile = vtk_generate_file(filename, pos)
-    for (key, value) in data
-        vtkfile[key, VTKPointData()] = value
-    end
-    vtk_save(vtkfile)
-end
-
 #--- Bounds ------------------------------------------------------------------------------------------------------------
 
 abstract type AbstractBounds end
@@ -227,3 +118,111 @@ function within(bounds::MeshBounds, p)
     length(pI) % 2 != 0
 end
 
+#--- Dose Positions ----------------------------------------------------------------------------------------------------
+
+abstract type DosePositions end
+
+Base.iterate(pos::DosePositions) = iterate(pos, 1)
+function Base.iterate(pos::DosePositions, i)
+    i>length(pos) && return nothing
+    pos[i], i+1
+end
+
+#--- DoseGrid ----------------------------------------------------------------------------------------------------------
+
+struct DoseGrid{Tx<:AbstractVector, Ty<:AbstractVector, Tz<:AbstractVector} <: DosePositions
+    x::Tx
+    y::Ty
+    z::Tz
+    indices::Vector{CartesianIndex{3}}
+    cells::Vector{Vector{Int}}
+end
+
+function DoseGrid(Δ, bounds::AbstractBounds)
+    xmin, xmax, ymin, ymax, zmin, zmax = boundsextent(bounds)
+
+    x = xmin:Δ:xmax
+    y = ymin:Δ:ymax
+    z = zmin:Δ:zmax
+
+    grid_index = CartesianIndices( (length(x), length(y), length(z)) )
+    indices = CartesianIndex{3}[]
+    linear_index = zeros(Int, length(x), length(y), length(z))
+
+    # Points
+    for i in grid_index
+        p = SVector(x[i[1]], y[i[2]], z[i[3]])
+        if(within(bounds, p))
+            push!(indices, grid_index[i])
+            linear_index[i] = length(indices)
+        end
+    end
+
+    # Cells
+
+    neighbours = vec([CartesianIndex(i,j,k) for i=0:1, j=0:1, k=0:1])[2:end]
+
+    cells = Vector{Int}[]
+    for i in eachindex(indices)
+        cell = [i]
+        for n in neighbours
+            index = indices[i] + n
+
+            if(checkbounds(Bool, linear_index, index) && linear_index[index] != 0)
+                push!(cell, linear_index[index])
+            end
+        end
+        if(length(cell)==8)
+            push!(cells, cell)
+        end
+    end
+
+    DoseGrid(x, y, z, indices, cells)
+end
+
+Base.:+(pos::DoseGrid, x) = DoseGrid(pos.x .+ x[1], pos.y .+ x[2], pos.z .+ x[3], pos.indices)
+
+Base.length(pos::DoseGrid) = length(pos.indices)
+Base.size(pos::DoseGrid) = (length(pos),)
+
+gridsize(pos::DoseGrid) = (length(pos.x), length(pos.y), length(pos.z))
+
+Base.getindex(pos::DoseGrid, i::Int, j::Int, k::Int) = SVector(pos.x[i], pos.y[j], pos.z[k])
+Base.getindex(pos::DoseGrid, i::CartesianIndex{3}) = pos[i[1], i[2], i[3]]
+Base.getindex(pos::DoseGrid, i::Int) = pos[pos.indices[i]]
+
+Base.eachindex(pos::DoseGrid) = eachindex(pos.indices)
+Base.CartesianIndices(pos::DoseGrid) = pos.indices
+
+#--- IO
+
+function Base.show(io::IO, pos::DoseGrid)
+    print(io, "x=")
+    Base.show(io, pos.x)
+    print(io, " y=")
+    Base.show(io, pos.y)
+    print(io, " z=")
+    Base.show(io, pos.z)
+    println(io, " npts=", length(pos.indices))
+end
+
+function vtk_create_cell(cell)
+    n = length(cell)
+    n==5 && return MeshCell(VTKCellTypes.VTK_PYRAMID, cell)
+    n==6 && return MeshCell(VTKCellTypes.VTK_WEDGE, cell)
+    n==8 && return MeshCell(VTKCellTypes.VTK_VOXEL, cell)
+end
+
+function vtk_generate_file(filename, pos::DoseGrid)
+    points = [pos[i] for i in eachindex(pos)]
+    cells = vtk_create_cell.(pos.cells)
+    vtk_grid(filename, points, cells)
+end
+
+function save(filename::String, pos::DoseGrid, data::Vararg) #
+    vtkfile = vtk_generate_file(filename, pos)
+    for (key, value) in data
+        vtkfile[key, VTKPointData()] = value
+    end
+    vtk_save(vtkfile)
+end

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -130,6 +130,17 @@ function Base.iterate(pos::DosePositions, i)
     pos[i], i+1
 end
 
+for op in (:+, :-)
+    eval(quote
+        function Base.$op(pos::DosePositions, v::AbstractVector{<:AbstractVector})
+            ($op).(pos, v)
+        end
+        function Base.$op(pos::DosePositions, v::AbstractVector{<:Real})
+            ($op).(pos, (v,))
+        end
+    end)
+end
+
 #--- AbstractDoseGrid ----------------------------------------------------------------------------------------------------------
 
 """
@@ -181,7 +192,7 @@ Base.getindex(pos::DoseGrid, i::Int) = pos[CartesianIndices(pos)[i]]
 
 for op in (:+, :-, :*, :/)
     eval(quote
-        function Base.$op(pos::DoseGrid, v::Union{AbstractVector,Tuple})
+        function Base.$op(pos::DoseGrid, v::AbstractVector{<:Real})
             DoseGrid( ($op).(getx(pos), v[1]), ($op).(gety(pos), v[2]), ($op).(getz(pos), v[3]))
         end
     end)
@@ -250,7 +261,7 @@ end
 
 for op in (:+, :-, :*, :/)
     eval(quote
-        function Base.$op(pos::DoseGridMasked, v::Union{AbstractVector,Tuple})
+        function Base.$op(pos::DoseGridMasked, v::AbstractVector{<:Real})
             x = ($op).(getx(pos), v[1])
             y = ($op).(gety(pos), v[2])
             z = ($op).(getz(pos), v[3])

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -226,3 +226,4 @@ function save(filename::String, pos::DoseGrid, data::Vararg) #
     end
     vtk_save(vtkfile)
 end
+save(filename::String, pos::DoseGrid, data::Dict) =  save(filename, pos, data...)

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -29,11 +29,11 @@ Returns `true` if the point `p` is within bounds
 """ within(bounds::AbstractBounds, p)
 
 """
-    boundingbox(bounds::AbstractBounds)
+    boundsextent(bounds::AbstractBounds)
 
 Returns the bounding box of the bounds as a 6 element tuple:
 `xmin`, `xmax`, `ymin`, `ymax`, `zmin`, `zmax`
-""" boundingbox(bounds::AbstractBounds)
+""" boundsextent(bounds::AbstractBounds)
 
 """
     CylinderBounds{T}
@@ -57,11 +57,11 @@ struct CylinderBounds{T} <: AbstractBounds
 end
 
 """
-    boundingbox(bounds::CylinderBounds)
+    boundsextent(bounds::CylinderBounds)
 
 For a cylinder
 """
-function boundingbox(bounds::CylinderBounds)
+function boundsextent(bounds::CylinderBounds)
     xmin, xmax = bounds.center[1] .+ 0.5*bounds.diameter*SVector(-1., 1.)
     ymin, ymax = bounds.center[2] .+ 0.5*bounds.diameter*SVector(-1., 1.)
     zmin, zmax = bounds.center[3] .+ 0.5*bounds.height*SVector(-1., 1.)
@@ -110,11 +110,11 @@ function MeshBounds(mesh, pad=10.) <: AbstractBounds
 end
 
 """
-    boundingbox(bounds::MeshBounds)
+    boundsextent(bounds::MeshBounds)
 
 For a mesh
 """
-boundingbox(bounds::MeshBounds) = bounds.box...
+boundsextent(bounds::MeshBounds) = bounds.box
 
 """
     within(bounds::MeshBounds, p)
@@ -125,7 +125,7 @@ function within(bounds::MeshBounds, p)
     dmin = minimum(norm.(Ref(Point(p)) .- vertices(bounds.mesh)))
     dmin<=bounds.pad && return true
 
-    xmin, xmax, ymin, ymax, zmin, zmax = boundingbox(bounds)
+    xmin, xmax, ymin, ymax, zmin, zmax = boundsextent(bounds)
     line = Segment(Point(xmin, ymin, zmin), Point(p))
     pI = intersect_mesh(line, bounds.mesh)
     

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -179,6 +179,14 @@ Base.CartesianIndices(pos::DoseGrid) = CartesianIndices(size(pos))
 
 Base.getindex(pos::DoseGrid, i::Int) = pos[CartesianIndices(pos)[i]]
 
+for op in (:+, :-, :*, :/)
+    eval(quote
+        function Base.$op(pos::DoseGrid, v::Union{AbstractVector,Tuple})
+            DoseGrid( ($op).(getx(pos), v[1]), ($op).(gety(pos), v[2]), ($op).(getz(pos), v[3]))
+        end
+    end)
+end
+
 #-- IO 
 
 function save(filename::String, pos::DoseGrid, data::Vararg)
@@ -240,7 +248,16 @@ function DoseGridMasked(Δ, bounds::AbstractBounds)
     DoseGridMasked(SVector(x, y, z), indices, cells)
 end
 
-Base.:+(pos::DoseGridMasked, x) = DoseGridMasked(pos.x .+ x[1], pos.y .+ x[2], pos.z .+ x[3], pos.indices)
+for op in (:+, :-, :*, :/)
+    eval(quote
+        function Base.$op(pos::DoseGridMasked, v::Union{AbstractVector,Tuple})
+            x = ($op).(getx(pos), v[1])
+            y = ($op).(gety(pos), v[2])
+            z = ($op).(getz(pos), v[3])
+            DoseGridMasked( SVector(x, y, z), pos.indices, pos.cells)
+        end
+    end)
+end
 
 Base.length(pos::DoseGridMasked) = length(pos.indices)
 Base.size(pos::DoseGridMasked) = (length(pos),)

--- a/src/DoseReconstructions.jl
+++ b/src/DoseReconstructions.jl
@@ -49,6 +49,8 @@ function reconstruct_dose(pos, surf, plan, calc; Δx=1., ΔMU=2., show_progess=t
         D = spzeros(length(bixels), length(pos))
         Ψ = zeros(size(bixels))
 
+        pos_fixed = patient_to_fixed(getisocenter(field)).(pos)
+
         if(show_progess)
             totalMU = 0.
             p = Progress(length(beams))
@@ -56,7 +58,7 @@ function reconstruct_dose(pos, surf, plan, calc; Δx=1., ΔMU=2., show_progess=t
 
         # Iterate through each control point in the field
         for i in eachindex(beams)
-            dose .+= dose_from_beam(pos, surf, beams[i], calc, bixels, D, Ψ)
+            dose .+= dose_from_beam(pos_fixed, surf, beams[i], calc, bixels, D, Ψ)
             # break
             
             if(show_progess)

--- a/src/Gantry.jl
+++ b/src/Gantry.jl
@@ -1,3 +1,4 @@
+export GantryPosition
 
 struct GantryPosition{T}
     gantry_angle::T

--- a/test/DosePoints.jl
+++ b/test/DosePoints.jl
@@ -1,0 +1,23 @@
+
+function test_operations(pos::DoseCalculations.AbstractDoseGrid)
+    @testset "Operations" begin
+        @testset "$(String(Symbol(op)))" for op in (+, -, *, /)
+            v = rand(3)
+            pos_new = op(pos, v)
+            
+            @test getx(pos_new) == op.(getx(pos), v[1])
+            @test gety(pos_new) == op.(gety(pos), v[2])
+            @test getz(pos_new) == op.(getz(pos), v[3])    
+        end
+    end
+end
+
+@testset "DoseGrid" begin
+    pos = DoseGrid(5., CylinderBounds(200., 200.))
+    test_operations(pos)
+end
+
+@testset "DoseGridMasked" begin
+    pos = DoseGridMasked(5., CylinderBounds(200., 200.))
+    test_operations(pos)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using DoseCalculations
     include("utils.jl")
     include("interpolation.jl")
     include("CoordinateSystems.jl")
+    include("DosePoints.jl")
     include("ExternalSurfaces.jl")
     include("meshes.jl")
     include("Fluence.jl")


### PR DESCRIPTION
This PR changes how dose positions and bounds work. 

Generally, bounds are now in the patient specific coordinate system, and hence generate dose positions in the same coordinate system. This makes using `MeshBounds` easier, as they are often in the patient coordinate system, but means the dose positions must be transformed into the IEC Fixed coordinate system.

For dose positions, the type system has been better defined. There is a new `AbstractDoseGrid`, which encompasses Cartesian dose grids. Currently, there are two concrete implementations, `DoseGrid` and `DoseGridMasked`:
* `DoseGrid` is a basic Cartesian grid.
* `DoseGridMasked` (previously `DoseGrid`) is a Cartesian grid, but not all points are used for the computation.

Other changes include:
* Updating the examples to use the new coordinate system
* Updated the water-phantom example to include more dose profiles
* Minor cosmetic change for the `ScaledIsoplaneKernel` constructor