### PR TITLE
Improved Dose Grids

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DoseCalculations"
 uuid = "b0d14063-c48a-4081-83d5-5a5ab48cb495"
 authors = ["lmejn <33491793+lmejn@users.noreply.github.com>"]
-version = "0.10.0"
+version = "0.11.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/examples/dose-from-single-aperture.jl
+++ b/examples/dose-from-single-aperture.jl
@@ -28,7 +28,7 @@ pos = DoseGridMasked(5., SurfaceBounds(surf), trans)
 pos_fixed = trans.(pos)
 
 # Create Bixels
-bixels = bixel_grid(getmlc(controlpoint), getjaws(controlpoint), 5.)
+bixels = BixelGrid(getmlc(controlpoint), getjaws(controlpoint), 5.)
 
 # Compute fluence map from aperture
 Ψ = fluence(bixels, getmlc(controlpoint)); # Compute the fluence

--- a/examples/fpbk-beam-commissioning.jl
+++ b/examples/fpbk-beam-commissioning.jl
@@ -281,7 +281,7 @@ surf = PlaneSurface(SSD)
 gantry = GantryPosition(0., 0., SAD)
 
 xb = -0.5*fieldsize:5.:0.5*fieldsize
-bixels = bixel_grid(xb, xb)
+bixels = BixelGrid(xb, xb)
 beamlets = Beamlet.(bixels, (gantry,))
 
 # Compute dose

--- a/examples/water-phantom.jl
+++ b/examples/water-phantom.jl
@@ -24,7 +24,7 @@ SSD = SAD
 
 # Create Fluence Grid
 xb = -0.5*fieldsize:5:0.5*fieldsize
-bixels = bixel_grid(xb, xb)
+bixels = BixelGrid(xb, xb)
 
 # Create dose calculation kernel
 calc = FinitePencilBeamKernel("path/to/kernel/file.jld")

--- a/src/DoseCalculationAlgorithms/FinitePencilBeamKernel.jl
+++ b/src/DoseCalculationAlgorithms/FinitePencilBeamKernel.jl
@@ -134,7 +134,7 @@ function calibrate!(calc::FinitePencilBeamKernel, MU, fieldsize, SAD, SSD=SAD;
     surf = PlaneSurface(SSD)
 
     xb = -0.5*fieldsize:beamlet_size:0.5*fieldsize
-    bixels = bixel_grid(xb, xb)
+    bixels = BixelGrid(xb, xb)
 
     gantry = GantryPosition(0., 0., SAD)
 

--- a/src/DoseCalculations.jl
+++ b/src/DoseCalculations.jl
@@ -58,6 +58,9 @@ include("Structures.jl")
 
 include("DoseReconstructions.jl")
 
+# Imports 
+import Base.IndexStyle
+
 export calibrate!
 
 export load, save, write_vtk, write_nrrd

--- a/src/DoseCalculations.jl
+++ b/src/DoseCalculations.jl
@@ -33,6 +33,9 @@ using Meshes
 
 import JSON
 
+# Imports 
+import Base.IndexStyle, Base.show
+
 include("utils/interpolation.jl")
 include("utils/misc.jl")
 
@@ -57,9 +60,6 @@ include("DoseFluenceMatrix.jl")
 include("Structures.jl")
 
 include("DoseReconstructions.jl")
-
-# Imports 
-import Base.IndexStyle
 
 export calibrate!
 

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -171,9 +171,9 @@ end
 
 A type of Dose Positions on a regular grid.
 
-Must have the fields `x`, `y`, and `z`.
+Must have `axes` field defined.
 """
-abstract type AbstractDoseGrid{T} <: AbstractArray{T, 3} end
+abstract type AbstractDoseGrid{T, N} <: AbstractArray{SVector{3, T}, N} end
 
 """
     getaxes(pos::AbstractDoseGrid[, dim])
@@ -185,23 +185,22 @@ Optionally, can specify which dimension.
 getaxes(pos::AbstractDoseGrid) = pos.axes
 getaxes(pos::AbstractDoseGrid, dim) = pos.axes[dim]
 
+gridsize(pos::AbstractDoseGrid) = tuple(length.(pos.axes)...)
+
 #--- DoseGrid ----------------------------------------------------------------------------------------------------------
 """
     DoseGrid
 
 Cartesian Dose Grid
 """
-struct DoseGrid{T<:Real, Tx, Ty, Tz} <: AbstractDoseGrid{T}
+struct DoseGrid{T, Tx<:AbstractVector, Ty<:AbstractVector, Tz<:AbstractVector} <: AbstractDoseGrid{T, 3}
     axes::Tuple{Tx, Ty, Tz}
     function DoseGrid(axes::Tuple{Tx, Ty, Tz}) where {T<:Real, 
         Tx<:AbstractVector{T}, Ty<:AbstractVector{T}, Tz<:AbstractVector{T}}
         new{T, Tx, Ty, Tz}((axes))
     end
-    function DoseGrid(x::Tx, y::Ty, z::Tz) where {T<:Real, 
-        Tx<:AbstractVector{T}, Ty<:AbstractVector{T}, Tz<:AbstractVector{T}}
-        new{T, Tx, Ty, Tz}((x, y, z))
-    end
 end
+DoseGrid(x, y, z) = DoseGrid((x, y, z))
 
 """
     DoseGrid(Δ, bounds::AbstractBounds)
@@ -220,13 +219,13 @@ function DoseGrid(Δ, bounds::AbstractBounds, transform=IdentityTransformation()
     DoseGrid(ax...)
 end
 
-Base.size(pos::DoseGrid) = tuple(length.(pos.axes)...)
+Base.size(pos::DoseGrid) = gridsize(pos)
 Base.IndexStyle(::Type{<:DoseGrid}) = IndexCartesian()
 Base.getindex(pos::DoseGrid, I::Vararg{Int, 3}) = SVector(getindex.(pos.axes, I))
 
 for op in (:+, :-, :*, :/)
     eval(quote
-        function Base.$op(pos::DoseGrid, v::AbstractVector{<:Real})
+        function Base.$op(pos::T, v::AbstractVector{<:Real}) where T<:DoseGrid
             x = ($op).(getaxes(pos, 1), v[1])
             y = ($op).(getaxes(pos, 2), v[2])
             z = ($op).(getaxes(pos, 3), v[3])
@@ -304,18 +303,34 @@ end
 
 Cartesian Dose Grid with a mask to reduce the number of dose points used.
 """
-struct DoseGridMasked{TVec<:AbstractVector}
-    axes::SVector{3, TVec}
+struct DoseGridMasked{T<:Real, Tx, Ty, Tz} <: AbstractDoseGrid{T, 1}
+    axes::Tuple{Tx, Ty, Tz}
     indices::Vector{CartesianIndex{3}}
-    cells::Vector{Vector{Int}}
-    function DoseGridMasked(x, y, z, indices, cells)
-        ax = x, y, z
-        if(!all(@. typeof(ax) <: StepRangeLen))
-            ax = collect.(ax)
-        end
-        new{typeof(ax[1])}(SVector(ax...), indices, cells)
+
+    function DoseGridMasked(axes::Tuple{Tx, Ty, Tz}, indices) where {T<:Real, 
+        Tx<:AbstractVector{T}, Ty<:AbstractVector{T}, Tz<:AbstractVector{T}}
+        new{T, Tx, Ty, Tz}(axes, indices)
     end
 end
+DoseGridMasked(x, y, z, indices) = DoseGridMasked((x, y, z), indices)
+
+Base.IndexStyle(::Type{<:DoseGridMasked}) = Base.IndexLinear()
+Base.size(pos::DoseGridMasked) = (length(pos.indices),)
+Base.CartesianIndices(pos::DoseGridMasked) = pos.indices
+
+function Base.getindex(pos::DoseGridMasked, i::Int)
+    I = CartesianIndices(pos)[i]
+    SVector(getindex.(pos.axes, Tuple(I)))
+end
+"""
+    getaxes(pos::DoseGrid[, dim])
+
+Return the axes of the grid.
+
+Optionally, can specify which dimension.
+"""
+getaxes(pos::DoseGridMasked) = pos.axes
+getaxes(pos::DoseGridMasked, dim) = pos.axes[dim]
 
 """
     DoseGridMasked(Δ, bounds::AbstractBounds, transform=I)
@@ -346,26 +361,7 @@ function DoseGridMasked(Δ, bounds::AbstractBounds, transform=IdentityTransforma
         end
     end
 
-    # Cells
-
-    neighbours = vec([CartesianIndex(i,j,k) for i=0:1, j=0:1, k=0:1])[2:end]
-
-    cells = Vector{Int}[]
-    for i in eachindex(indices)
-        cell = [i]
-        for n in neighbours
-            index = indices[i] + n
-
-            if(checkbounds(Bool, linear_index, index) && linear_index[index] != 0)
-                push!(cell, linear_index[index])
-            end
-        end
-        if(length(cell)==8)
-            push!(cells, cell)
-        end
-    end
-
-    DoseGridMasked(x, y, z, indices, cells)
+    DoseGridMasked(x, y, z, indices)
 end
 
 for op in (:+, :-, :*, :/)
@@ -374,23 +370,14 @@ for op in (:+, :-, :*, :/)
             x = ($op).(getaxes(pos, 1), v[1])
             y = ($op).(getaxes(pos, 2), v[2])
             z = ($op).(getaxes(pos, 3), v[3])
-            DoseGridMasked(x, y, z, pos.indices, pos.cells)
+            DoseGridMasked(x, y, z, pos.indices)
         end
     end)
 end
 
-Base.length(pos::DoseGridMasked) = length(pos.indices)
-Base.size(pos::DoseGridMasked) = (length(pos),)
 
-gridsize(pos::DoseGridMasked) = tuple(length.(pos.axes)...)
-
-Base.getindex(pos::DoseGridMasked, i::Int) = pos[pos.indices[i]]
-
-Base.eachindex(pos::DoseGridMasked) = eachindex(pos.indices)
-Base.CartesianIndices(pos::DoseGridMasked) = pos.indices
 
 #--- IO
-
 function Base.show(io::IO, pos::DoseGridMasked)
     print(io, "x=")
     Base.show(io, pos.axes[1])
@@ -404,11 +391,43 @@ end
 # VTK
 
 """
-    vtk_create_cell(cell)
+    _get_cells(pos)
+
+Returns a list of cell connectivities
+"""
+function _get_cells(pos)
+    neighbours = vec([CartesianIndex(i,j,k) for i=0:1, j=0:1, k=0:1])[2:end]
+
+    indices = CartesianIndices(pos)
+    linear_index = zeros(gridsize(pos))
+
+    for i in eachindex(pos)
+        linear_index[indices[i]] = i
+    end
+
+    cells = Vector{Int}[]
+    for i in eachindex(indices)
+        cell = [i]
+    
+        for n in neighbours
+            index = indices[i] + n
+            if(checkbounds(Bool, linear_index, index) && linear_index[index]!=0)
+                push!(cell, linear_index[index])
+            end
+        end
+        if(length(cell)==8)
+            push!(cells, cell)
+        end
+    end
+    cells
+end
+
+"""
+    _vtk_create_cell(cell)
 
 Return the VTK cell type for a list of cell indices.
 """
-function vtk_create_cell(cell)
+function _vtk_create_cell(cell)
     n = length(cell)
     n==5 && return MeshCell(VTKCellTypes.VTK_PYRAMID, cell)
     n==6 && return MeshCell(VTKCellTypes.VTK_WEDGE, cell)
@@ -421,8 +440,9 @@ end
 Save `DoseGridMasked` to the VTK Unstructured Grid (vtu) format.
 """
 function write_vtk(filename::String, pos::DoseGridMasked, data::Vararg)
-    points = [pos[i] for i in eachindex(pos)]
-    cells = vtk_create_cell.(pos.cells)
+    points = collect(pos)
+    
+    cells = _vtk_create_cell.(_get_cells(pos))
 
     vtk_grid(filename, points, cells) do vtkfile
         for (key, value) in data
@@ -467,9 +487,6 @@ function save(file::HDF5.H5DataStore, pos::DoseGridMasked)
 
     file["pos/indices"] = hcat(collect.(Tuple.(pos.indices))...)
 
-    file["cells/index"] = cumsum(vcat(1, length.(pos.cells)))
-    file["cells/cells"] = vcat(pos.cells...)
-
     nothing
 end
 
@@ -487,9 +504,5 @@ function load(::Type{DoseGridMasked}, file::HDF5.H5DataStore)
     indices = read(file["pos/indices"])
     indices = [CartesianIndex(col...) for col in eachcol(indices)]
 
-    index = read(file["cells/index"])
-    cells = read(file["cells/cells"])
-    cells = [cells[index[i]:index[i+1]-1] for i in 1:length(index)-1]
-
-    DoseGridMasked(x, y, z, indices, cells)
+    DoseGridMasked(x, y, z, indices)
 end

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -143,31 +143,10 @@ Whether `p` is within the mesh
 """
 within(bounds::SurfaceBounds, p) = isinside(bounds.surf, p)
 
-#--- Dose Positions ----------------------------------------------------------------------------------------------------
-
-abstract type DosePositions end
-
-Base.iterate(pos::DosePositions) = iterate(pos, 1)
-function Base.iterate(pos::DosePositions, i)
-    i>length(pos) && return nothing
-    pos[i], i+1
-end
-
-for op in (:+, :-)
-    eval(quote
-        function Base.$op(pos::DosePositions, v::AbstractVector{<:AbstractVector})
-            ($op).(pos, v)
-        end
-        function Base.$op(pos::DosePositions, v::AbstractVector{<:Real})
-            ($op).(pos, (v,))
-        end
-    end)
-end
-
 #--- AbstractDoseGrid ----------------------------------------------------------------------------------------------------------
 
 """
-    AbstractDoseGrid <: DosePositions
+    AbstractDoseGrid
 
 A type of Dose Positions on a regular grid.
 

--- a/src/Fluence.jl
+++ b/src/Fluence.jl
@@ -138,7 +138,7 @@ end
 BixelGrid(x, y) = BixelGrid((x, y))
 
 Base.size(grid::BixelGrid) = tuple(length(grid.axes[1])-1,
-                                    length(grid.axes[2])-1)
+                                   length(grid.axes[2])-1)
 
 function Base.getindex(grid::BixelGrid, I::Vararg{Int, 2})
     lb = @. getindex(grid.axes, I)
@@ -188,25 +188,6 @@ function BixelGrid(jaws::Jaws, Δx, Δy)
     BixelGrid(xrange, yrange)
 end
 BixelGrid(jaws::Jaws, Δ) = BixelGrid(jaws, Δ, Δ)
-
-"""
-    BixelGrid(mlc::AbstractMultiLeafCollimator, jaws::Jaws, Δx)
-
-Grid that fits in an MLC and the jaws.
-
-Bixel y widths are of the same width as the MLC leaf widths. Creates smaller widths
-in the case where the jaws are halfway within a leaf width. Bixel x widths are
-set by `Δx`.`
-"""
-function BixelGrid(mlc::AbstractMultiLeafCollimator, jaws::Jaws, Δx)
-
-    j1, j2 = locate.(Ref(mlc), gety(jaws))
-
-    y = clamp.(getedges(mlc)[j1:j2+1], gety(jaws)...)
-    x = clamp.(snapped_range(getx(jaws)..., Δx), getx(jaws)...)
-
-    BixelGrid(x, y)
-end
 
 """
     bixels_from_bld(args::AbstractBeamLimitingDevice...)

--- a/src/Fluence.jl
+++ b/src/Fluence.jl
@@ -4,8 +4,6 @@
 # Functions for creating fluence grids and computing fluence from beam-limiting
 # devices.
 #
-import Base.IndexStyle
-
 export fluence, fluence!, bixels_from_bld
 
 export Bixel, getcenter, getwidth, getedge, getarea, subdivide

--- a/test/DosePoints.jl
+++ b/test/DosePoints.jl
@@ -67,9 +67,9 @@
     end
 end
 
-@testset "DosePoints" begin
+# @testset "DosePoints" begin
 
-    function test_operations(pos::DoseCalculations.AbstractDoseGrid)
+    function test_operations(pos)
         @testset "Operations" begin
             @testset "$(String(Symbol(op)))" for op in (+, -, *, /)
                 v = rand(3)
@@ -84,36 +84,27 @@ end
 
     @testset "DoseGrid" begin
 
-        axes = (-10.:1.:10., 10.:2.:20, -20.:5.:30.)
-        pos = DoseGrid(axes...)
-        
+        x, y, z = -10.:3.:10., 10.:5.:20, -20.:15.:30.
+        axes = (x, y, z)
+        pos = DoseGrid(axes)
+
         n = length.(axes)
-        N = prod(n)
+
+        # Other Constructor
+        @test pos == DoseGrid(x, y, z)
+        
+        # Base Methods
         
         @test size(pos) == n
-        @test length(pos) == N
-        
-        @test eachindex(pos) == Base.OneTo(N)
-        @test CartesianIndices(pos) == CartesianIndices(n)
-
+        @test eachindex(pos) == CartesianIndices(n)
+    
         @test Tuple(getaxes(pos)) == axes
+        @test getaxes(pos, 2) == axes[2]
         
-        # Linear Indexing
-        index = rand(1:N)
-        gridindex = Tuple(CartesianIndices(n)[index])
-        @test pos[index] ≈ SVector(getindex.(axes, gridindex))
-        
-        # Cartesian Indexing
+        # Indexing
         index = rand(CartesianIndices(n))
         @test pos[index] ≈ SVector(getindex.(axes, Tuple(index)))
         @test pos[Tuple(index)...] ≈ pos[index]
-        
-        # Iteration
-        p, i = iterate(pos)
-        @test p ≈ pos[1] && i==2
-        
-        p, i = iterate(pos, 2)
-        @test p ≈ pos[2] && i==3
 
         test_operations(pos)
 
@@ -222,4 +213,4 @@ end
 
         @testset "IO - HDF5" test_hdf5(pos)
     end
-end
+# end

--- a/test/ScaledIsoplaneKernel.jl
+++ b/test/ScaledIsoplaneKernel.jl
@@ -44,7 +44,7 @@ See src/DoseCalculationAlgorithms/ScaledIsoplaneKernel.jl
         calc = ScaledIsoplaneKernel("src/DoseCalculationAlgorithms/sample-kernel-data/6x/", 280.)
 
         function get_dose(Δx, Δy)
-            bixels = DoseCalculations.bixel_grid(jaws, Δx, Δy)
+            bixels = DoseCalculations.BixelGrid(jaws, Δx, Δy)
             sum(dose_fluence_matrix(pos, vec(bixels), surf, calc))
         end
 

--- a/test/TreatmentField.jl
+++ b/test/TreatmentField.jl
@@ -71,7 +71,7 @@ end
         @test getΔMU(field, 3) == 0.5*(meterset[4]-meterset[2])
         @test getΔMU(field, ncontrol) == 0.5*(meterset[ncontrol]-meterset[ncontrol-1])
     
-        @test sum(getΔMU.(Ref(field), 1:ncontrol)) == meterset[end]
+        @test sum(getΔMU.(Ref(field), 1:ncontrol)) ≈ meterset[end]
     end
 
     @testset "Resample" begin


### PR DESCRIPTION
Tidied `AbstractDoseGrid`. It now is a subtype of `AbstractArray`, which comes with a rich set of methods. Things like broadcasting work well now.

Also "fixed" a bug in `BixelGrid`, which caused zero width bixels. The constructor from MLC has been removed to avoid this error, and tests have been added.