### PR TITLE
Dose Volume

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DoseCalculations"
 uuid = "b0d14063-c48a-4081-83d5-5a5ab48cb495"
 authors = ["lmejn <33491793+lmejn@users.noreply.github.com>"]
-version = "0.12.2"
+version = "0.13.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/DoseCalculations.jl
+++ b/src/DoseCalculations.jl
@@ -52,6 +52,8 @@ include("ExternalSurfaces.jl")
 
 include("DosePoints.jl")
 
+include("DoseVolume.jl")
+
 include("Fluence.jl")
 include("DoseCalculationAlgorithms/DoseCalculationAlgorithms.jl")
 

--- a/src/DoseCalculations.jl
+++ b/src/DoseCalculations.jl
@@ -52,8 +52,6 @@ include("ExternalSurfaces.jl")
 
 include("DosePoints.jl")
 
-include("DoseVolume.jl")
-
 include("Fluence.jl")
 include("DoseCalculationAlgorithms/DoseCalculationAlgorithms.jl")
 
@@ -61,11 +59,15 @@ include("DoseFluenceMatrix.jl")
 
 include("Structures.jl")
 
+include("DoseVolume.jl")
+
 include("DoseReconstructions.jl")
 
 export calibrate!
 
 export load, save, write_vtk, write_nrrd
+
+export DoseVolume, getpositions, getsurface
 
 export BixelGrid
 export MockKernel

--- a/src/DoseFluenceMatrix.jl
+++ b/src/DoseFluenceMatrix.jl
@@ -20,7 +20,7 @@ See `dose_fluence_matrix!` for implementation.
 function dose_fluence_matrix(T::Type{<:AbstractMatrix}, pos, beamlets::AbstractArray{<:AbstractBeamlet},
                              surf::AbstractExternalSurface, calc::AbstractDoseAlgorithm;
                              kwargs...)
-    D = T{Float64}(undef, length(pos), length(beamlets))
+    D = zeros(length(pos), length(beamlets))
     dose_fluence_matrix!(D, pos, beamlets, surf, calc; kwargs...)
 end
 
@@ -105,7 +105,7 @@ end
 
 Ensures size of D is correct
 """
-_assert_size(D, pos, beamlets) = @assert size(D) == (length(pos), length(beamlets))
+_assert_size(D, pos, beamlets) = @assert size(D) == (size(pos, 1), size(beamlets, 1))
 
 function point_dose(pos::SVector{3, T}, beamlet, surf, calc, maxradius) where T<:Number
     src = source_position(beamlet)

--- a/src/DosePoints.jl
+++ b/src/DosePoints.jl
@@ -230,8 +230,8 @@ end
 write_vtk(filename::String, pos::DoseGrid, data::Dict) =  write_vtk(filename, pos, data...)
 
 function get_nrrd_props(pos::AbstractDoseGrid)
-    origin = tuple(pos[1, 1, 1]...)
     x, y, z = getaxes(pos)
+    origin = x[1], y[1], z[1]
     directions = (step(x), 0, 0), (0, step(y), 0), (0, 0, step(z))
     
     Dict("space origin"=>origin,

--- a/src/DoseVolume.jl
+++ b/src/DoseVolume.jl
@@ -1,8 +1,5 @@
 abstract type AbstractDoseVolume end
 
-getdepth(vol::AbstractDoseVolume) = getdepth.(vol.pos, (vol.surf),)
-getSSD(vol::AbstractDoseVolume) = getSSD.(vol.pos, (vol.surf),)
-
 struct DoseVolume{TPos<:AbstractArray, TSurf<:AbstractExternalSurface} <: AbstractDoseVolume
     positions::TPos
     surface::TSurf

--- a/src/DoseVolume.jl
+++ b/src/DoseVolume.jl
@@ -25,7 +25,7 @@ getsurface(vol::DoseVolume) = vol.surface
 Gets positions and surface from `vol`
 """
 function dose_fluence_matrix!(D, vol::AbstractDoseVolume, beamlets, calc; kwargs...)
-    dose_fluence_matrix!(D, getpositions(vol), beamlets, getpositions(surf), calc;
+    dose_fluence_matrix!(D, vec(getpositions(vol)), beamlets, getsurface(vol), calc;
         kwargs...)
 end
 
@@ -35,7 +35,7 @@ end
 Gets positions and surface from `vol`
 """
 function dose_fluence_matrix(T, vol::AbstractDoseVolume, beamlets, calc; kwargs...)
-    dose_fluence_matrix(T, getpositions(vol), beamlets, getpositions(surf), calc;
+    dose_fluence_matrix(T, vec(getpositions(vol)), beamlets, getsurface(vol), calc;
         kwargs...)
 end
 

--- a/src/DoseVolume.jl
+++ b/src/DoseVolume.jl
@@ -1,0 +1,13 @@
+abstract type AbstractDoseVolume end
+
+getdepth(vol::AbstractDoseVolume) = getdepth.(vol.pos, (vol.surf),)
+getSSD(vol::AbstractDoseVolume) = getSSD.(vol.pos, (vol.surf),)
+
+struct DoseVolume{TPos<:AbstractArray, TSurf<:AbstractExternalSurface} <: AbstractDoseVolume
+    positions::TPos
+    surface::TSurf
+end
+
+getpositions(vol::DoseVolume) = vol.positions
+getsurface(vol::DoseVolume) = vol.surface
+

--- a/src/DoseVolume.jl
+++ b/src/DoseVolume.jl
@@ -8,14 +8,35 @@ struct DoseVolume{TPos<:AbstractArray, TSurf<:AbstractExternalSurface} <: Abstra
     surface::TSurf
 end
 
+"""
+    getpositions(vol::DoseVolume)
+
+Get dose positions/grid
+"""
 getpositions(vol::DoseVolume) = vol.positions
+
+"""
+    getsurface(vol::DoseVolume)
+
+Get surface
+"""
 getsurface(vol::DoseVolume) = vol.surface
 
+"""
+    dose_fluence_matrix!(D, vol, beamlets, calc)
+
+Gets positions and surface from `vol`
+"""
 function dose_fluence_matrix!(D, vol::AbstractDoseVolume, beamlets, calc; kwargs...)
     dose_fluence_matrix!(D, getpositions(vol), beamlets, getpositions(surf), calc;
         kwargs...)
 end
 
+"""
+    dose_fluence_matrix(T, vol, beamlets, calc)
+
+Gets positions and surface from `vol`
+"""
 function dose_fluence_matrix(T, vol::AbstractDoseVolume, beamlets, calc; kwargs...)
     dose_fluence_matrix(T, getpositions(vol), beamlets, getpositions(surf), calc;
         kwargs...)

--- a/src/DoseVolume.jl
+++ b/src/DoseVolume.jl
@@ -11,3 +11,14 @@ end
 getpositions(vol::DoseVolume) = vol.positions
 getsurface(vol::DoseVolume) = vol.surface
 
+function dose_fluence_matrix!(D, vol::AbstractDoseVolume, beamlets, calc; kwargs...)
+    dose_fluence_matrix!(D, getpositions(vol), beamlets, getpositions(surf), calc;
+        kwargs...)
+end
+
+function dose_fluence_matrix(T, vol::AbstractDoseVolume, beamlets, calc; kwargs...)
+    dose_fluence_matrix(T, getpositions(vol), beamlets, getpositions(surf), calc;
+        kwargs...)
+end
+
+Adapt.@adapt_structure DoseVolume

--- a/test/DoseFluenceMatrix.jl
+++ b/test/DoseFluenceMatrix.jl
@@ -83,6 +83,6 @@ end
 
     Dsaved = JLD2.load("test-data/dose_fluence_matrix.jld2", "mock-kernel")
 
-    @test Dsaved == dose_fluence_matrix(Matrix, pos, beamlets, surf, calc; maxradius=5.)
-    @test Dsaved == dose_fluence_matrix(SparseMatrixCSC, pos, beamlets, surf, calc; maxradius=5.)
+    @test Dsaved == dose_fluence_matrix(Matrix, vec(pos), vec(beamlets), surf, calc; maxradius=5.)
+    @test Dsaved == dose_fluence_matrix(SparseMatrixCSC, vec(pos), vec(beamlets), surf, calc; maxradius=5.)
 end

--- a/test/DoseVolume.jl
+++ b/test/DoseVolume.jl
@@ -1,11 +1,24 @@
 
 @testset "Dose Volume" begin
-    x = -10:1.:10
+    x = -10:10.:10
     pos = DoseGrid(x, x, x)
-    surf = PlaneSurface(800.)
+    surf = ConstantSurface(800.)
 
     vol = DoseVolume(pos, surf)
 
     @test pos == getpositions(vol)
     @test surf == getsurface(vol)
+
+    beamlet = Beamlet(Bixel(0., 0., 1., 1.), GantryPosition(0., 0., 1000.))
+    calc = MockKernel()
+
+    D_truth = dose_fluence_matrix(Matrix, vec(pos), [beamlet], surf, calc)
+
+    D_vol = dose_fluence_matrix(Matrix, vol, [beamlet], calc)
+    @test D_vol ≈ D_truth
+
+    D_vol .= 0
+    dose_fluence_matrix!(D_vol, vol, [beamlet], calc)
+    @test D_vol ≈ D_truth
+    
 end

--- a/test/DoseVolume.jl
+++ b/test/DoseVolume.jl
@@ -1,0 +1,11 @@
+
+@testset "Dose Volume" begin
+    x = -10:1.:10
+    pos = DoseGrid(x, x, x)
+    surf = PlaneSurface(800.)
+
+    vol = DoseVolume(pos, surf)
+
+    @test pos == getpositions(vol)
+    @test surf == getsurface(vol)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ using QuadGK, HCubature
     include("DosePoints.jl")
     include("DoseFluenceMatrix.jl")
     include("ExternalSurfaces.jl")
+    include("DoseVolume.jl")
     include("meshes.jl")
     include("Bixels.jl")
     include("Beamlet.jl")


### PR DESCRIPTION
Implemented `AbstractDoseVolume`. This is a data type that holds all patient based information for computing dose. Currently, `DoseVolume` is implemented, which holds both dose position and external surface information. It may be further extended to add electron density information (#45) 